### PR TITLE
Default to no sound if a sound is not included

### DIFF
--- a/Jaunt/Behaviors/EntityBehaviorGait.cs
+++ b/Jaunt/Behaviors/EntityBehaviorGait.cs
@@ -82,7 +82,6 @@ namespace Jaunt.Behaviors
             {
                 Gaits[gait.Code] = gait;
 
-                gait.Sound ??= new AssetLocation("game:creature/hooved/" + gait.Code); // Default sound path if not defined
                 if (gait.IconTexture is not null) ModSystem.hudIconRenderer?.RegisterTexture(gait.IconTexture);
             }
             


### PR DESCRIPTION
Fixes [Warning] Audio File not found: game:sounds/creature/hooved/idle.ogg
Allows gaits to be silent without a warning being printed or an empty ogg file